### PR TITLE
fix(issue#40): 修改刷新逻辑改为先尊重本地生命周期锁定状态

### DIFF
--- a/backend/internal/app/vps/service.go
+++ b/backend/internal/app/vps/service.go
@@ -105,8 +105,8 @@ func (s *Service) RefreshStatus(ctx context.Context, inst domain.VPSInstance) (d
 	if err != nil {
 		return domain.VPSInstance{}, err
 	}
-	status := MapAutomationState(info.State)
-	if err := s.vps.UpdateInstanceStatus(ctx, inst.ID, status, info.State); err != nil {
+	status, automationState := refreshLifecycleStatus(inst, info.State)
+	if err := s.vps.UpdateInstanceStatus(ctx, inst.ID, status, automationState); err != nil {
 		return domain.VPSInstance{}, err
 	}
 	if info.RemoteIP != "" || info.PanelPassword != "" || info.VNCPassword != "" {
@@ -119,6 +119,20 @@ func (s *Service) RefreshStatus(ctx context.Context, inst domain.VPSInstance) (d
 		}
 	}
 	return s.vps.GetInstance(ctx, inst.ID)
+}
+
+func refreshLifecycleStatus(inst domain.VPSInstance, automationState int) (domain.VPSStatus, int) {
+	status := MapAutomationState(automationState)
+	if inst.AdminStatus == "" || inst.AdminStatus == domain.VPSAdminStatusNormal {
+		if inst.Status == domain.VPSStatusExpiredLocked && inst.ExpireAt != nil && !inst.ExpireAt.After(time.Now()) {
+			return domain.VPSStatusExpiredLocked, 10
+		}
+		return status, automationState
+	}
+	if inst.AdminStatus == domain.VPSAdminStatusLocked && inst.ExpireAt != nil && !inst.ExpireAt.After(time.Now()) {
+		return domain.VPSStatusExpiredLocked, 10
+	}
+	return domain.VPSStatusLocked, 10
 }
 
 func (s *Service) SetStatus(ctx context.Context, inst domain.VPSInstance, status domain.VPSStatus, automationState int) error {

--- a/backend/internal/app/vps/service_test.go
+++ b/backend/internal/app/vps/service_test.go
@@ -97,6 +97,58 @@ func TestVPSService_RefreshStatus(t *testing.T) {
 	}
 }
 
+func TestVPSService_RefreshStatus_PreservesExpiredLockState(t *testing.T) {
+	_, repo := testutil.NewTestDB(t, false)
+	user := testutil.CreateUser(t, repo, "v3-lock", "v3-lock@example.com", "pass")
+
+	order := domain.Order{UserID: user.ID, OrderNo: "ORD-VPS-LOCK", Status: domain.OrderStatusApproved, TotalAmount: 1000, Currency: "CNY"}
+	if err := repo.CreateOrder(context.Background(), &order); err != nil {
+		t.Fatalf("create order: %v", err)
+	}
+	item := domain.OrderItem{OrderID: order.ID, Amount: 1000, Status: domain.OrderItemStatusApproved, Action: "create", SpecJSON: "{}"}
+	if err := repo.CreateOrderItems(context.Background(), []domain.OrderItem{item}); err != nil {
+		t.Fatalf("create item: %v", err)
+	}
+	items, _ := repo.ListOrderItems(context.Background(), order.ID)
+
+	expiredAt := time.Now().Add(-2 * time.Hour)
+	inst := domain.VPSInstance{
+		UserID:               user.ID,
+		OrderItemID:          items[0].ID,
+		AutomationInstanceID: "101",
+		Name:                 "expired-vm",
+		SystemID:             1,
+		Status:               domain.VPSStatusExpiredLocked,
+		AutomationState:      10,
+		AdminStatus:          domain.VPSAdminStatusLocked,
+		SpecJSON:             "{}",
+		ExpireAt:             &expiredAt,
+	}
+	if err := repo.CreateInstance(context.Background(), &inst); err != nil {
+		t.Fatalf("create vps: %v", err)
+	}
+	fakeAuto := &testutil.FakeAutomationClient{
+		HostInfo: map[int64]appshared.AutomationHostInfo{
+			101: {HostID: 101, State: 2, RemoteIP: "2.2.2.3"},
+		},
+	}
+	autoResolver := &testutil.FakeAutomationResolver{Client: fakeAuto}
+	svc := appvps.NewService(repo, autoResolver, repo)
+	if _, err := svc.RefreshStatus(context.Background(), inst); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	updated, err := repo.GetInstance(context.Background(), inst.ID)
+	if err != nil {
+		t.Fatalf("get updated instance: %v", err)
+	}
+	if updated.Status != domain.VPSStatusExpiredLocked {
+		t.Fatalf("expected expired locked status preserved, got %s", updated.Status)
+	}
+	if updated.AutomationState != 10 {
+		t.Fatalf("expected automation state 10 preserved for locked instance, got %d", updated.AutomationState)
+	}
+}
+
 func TestVPSService_Actions(t *testing.T) {
 	_, repo := testutil.NewTestDB(t, false)
 	user := testutil.CreateUser(t, repo, "v4", "v4@example.com", "pass")


### PR DESCRIPTION
This pull request enhances the VPS status refresh logic to better handle expired and locked instances, ensuring that their status and automation state are correctly preserved. It introduces a new helper function to encapsulate this logic and adds a targeted unit test to verify the behavior.

**Improvements to VPS status refresh logic:**

* Added a new helper function `refreshLifecycleStatus` in `service.go` to centralize and clarify the logic for determining the correct `VPSStatus` and `automationState`, especially for expired and locked instances. This ensures that instances in an expired locked state retain their status and automation state appropriately.
* Updated the `RefreshStatus` method to use the new `refreshLifecycleStatus` function, improving maintainability and correctness of status updates.

**Testing enhancements:**

* Added a new test `TestVPSService_RefreshStatus_PreservesExpiredLockState` in `service_test.go` to verify that the refresh logic preserves the `ExpiredLocked` status and automation state for locked and expired instances.